### PR TITLE
Changing references from old SVN to GitHub

### DIFF
--- a/lib/Net/Server/Mail.pm
+++ b/lib/Net/Server/Mail.pm
@@ -719,13 +719,13 @@ Olivier Poitrey E<lt>rs@rhapsodyk.netE<gt>
 
 Available on CPAN.
 
-anonymous SVN repository:
+anonymous Git repository:
 
-svn co https://emailproject.perl.org/svn/Net-Server-Mail
+git clone git://github.com/rs/net-server-mail.git
 
-SVN repository on the web:
+Git repository on the web:
 
-http://emailproject.perl.org/svn/Net-Server-Mail/
+L<https://github.com/rs/net-server-mail>
 
 =head1 BUGS
 

--- a/lib/Net/Server/Mail/ESMTP.pm
+++ b/lib/Net/Server/Mail/ESMTP.pm
@@ -313,13 +313,13 @@ Olivier Poitrey E<lt>rs@rhapsodyk.netE<gt>
 
 Available on CPAN.
 
-anonymous SVN repository:
+anonymous Git repository:
 
-svn co https://emailproject.perl.org/svn/Net-Server-Mail
+git clone git://github.com/rs/net-server-mail.git
 
-SVN repository on the web:
+Git repository on the web:
 
-http://emailproject.perl.org/svn/Net-Server-Mail/
+L<https://github.com/rs/net-server-mail>
 
 =head1 BUGS
 

--- a/lib/Net/Server/Mail/LMTP.pm
+++ b/lib/Net/Server/Mail/LMTP.pm
@@ -202,13 +202,13 @@ Olivier Poitrey E<lt>rs@rhapsodyk.netE<gt>
 
 Available on CPAN.
 
-anonymous SVN repository:
+anonymous Git repository:
 
-svn co https://emailproject.perl.org/svn/Net-Server-Mail
+git clone git://github.com/rs/net-server-mail.git
 
-SVN repository on the web:
+Git repository on the web:
 
-http://emailproject.perl.org/svn/Net-Server-Mail/
+L<https://github.com/rs/net-server-mail>
 
 =head1 BUGS
 

--- a/lib/Net/Server/Mail/SMTP.pm
+++ b/lib/Net/Server/Mail/SMTP.pm
@@ -736,13 +736,13 @@ Olivier Poitrey E<lt>rs@rhapsodyk.netE<gt>
 
 Available on CPAN.
 
-anonymous SVN repository:
+anonymous Git repository:
 
-svn co https://emailproject.perl.org/svn/Net-Server-Mail
+git clone git://github.com/rs/net-server-mail.git
 
-SVN repository on the web:
+Git repository on the web:
 
-http://emailproject.perl.org/svn/Net-Server-Mail/
+L<https://github.com/rs/net-server-mail>
 
 =head1 BUGS
 


### PR DESCRIPTION
Since you've moved it to GitHub, might as well update the URLs.
