### PR TITLE
Fix failing test, fixes GH #8

### DIFF
--- a/t/lmtp.t
+++ b/t/lmtp.t
@@ -2,7 +2,7 @@ use strict;
 use Test::More;
 use IO::Socket;
 
-plan tests => 11;
+plan tests => 10;
 
 eval('use Net::LMTP');
 SKIP: {
@@ -48,7 +48,6 @@ SKIP: {
     ok( $lmtp->data );
     ok( $lmtp->datasend('To: postmaster') );
     ok( $lmtp->dataend );
-    ok( $lmtp->response );
     ok( $lmtp->quit );
 
     kill 1, $pid;


### PR DESCRIPTION
As described in GH #8, there is a failing test which appears to call `response` twice. The first time succeeds (and if `quit` is called right after, that succeeds too).

The second time, however, called explicitly, it fails with a time-out (since the server probably already responded and has nothing more to respond). The following call to `quit` then fails too.

I would be happy if someone with more experience will review this to make sure I'm not wrong.

(This PR is part of PRC.)